### PR TITLE
[OPP-1331] kjører nginx alltid på 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,6 @@ services:
       - modialogin
       - echo-server
     environment:
-      APP_PORT: "8080"
       APP_NAME: "frontend"
       APP_VERSION: "localhost"
       IDP_DISCOVERY_URL: "http://oidc-stub:8080/.well-known/openid-configuration"

--- a/frontend-image/Dockerfile
+++ b/frontend-image/Dockerfile
@@ -20,6 +20,6 @@ RUN mkdir -p /app
 # Just a small default-app that show how the image may be used.
 COPY default-app /app
 
-EXPOSE 8080 443
+EXPOSE 8080
 
 CMD ["start-nginx"]

--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -33,7 +33,7 @@ access_log  /dev/stdout  main;
 
 server {
     server_name _;
-    listen "${APP_PORT}";
+    listen 8080;
     root "/app-source";
 
     # Setting some variables for use within lua-scripts

--- a/frontend-image/start-nginx.sh
+++ b/frontend-image/start-nginx.sh
@@ -37,7 +37,6 @@ requireEnv() {
 export RESOLVER=$(cat /etc/resolv.conf | grep -v '^#' | grep -m 1 nameserver | awk '{print $2}') # Picking the first nameserver.
 
 # Settings default environment variabels
-export APP_PORT="${APP_PORT:-443}"
 export CSP_DIRECTIVES="${CSP_DIRECTIVES:-default-src 'self';}"
 export CSP_REPORT_ONLY="${CSP_REPORT_ONLY:-false}"
 
@@ -71,7 +70,6 @@ then
 fi
 
 declare -a ENV_VARIABLES=(
-  '$APP_PORT'
   '$APP_NAME'
   '$APP_VERSION'
   '$IDP_DISCOVERY_URL'


### PR DESCRIPTION
vi har ikke behov for å bruke en 443 som port, og da er det mer vanlig at 8080 er brukt på huset