### PR TITLE
[PROD][KAIZEN-0] fjerne duplikat logging

### DIFF
--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -1,4 +1,5 @@
 charset utf-8;
+access_log   off; # Handled by trafic
 error_log    /dev/stdout  info;
 
 lua_package_path '~/lua/?.lua;;';
@@ -25,12 +26,6 @@ map "${CSP_REPORT_ONLY}" $csp_enforce_directives {
     "true"    '';
     default   "${CSP_DIRECTIVES}";
 }
-
-#log_format main         '[$time_local] '
-#                        '"$request_masked" $status "$sent_http_location_masked" '
-#                        '"$http_referer_masked" "$http_user_agent"';
-#access_log  /dev/stdout  main;
-access_log off; # Handled by trafic
 
 server {
     server_name _;

--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -26,10 +26,11 @@ map "${CSP_REPORT_ONLY}" $csp_enforce_directives {
     default   "${CSP_DIRECTIVES}";
 }
 
-log_format main         '[$time_local] '
-                        '"$request_masked" $status "$sent_http_location_masked" '
-                        '"$http_referer_masked" "$http_user_agent"';
-access_log  /dev/stdout  main;
+#log_format main         '[$time_local] '
+#                        '"$request_masked" $status "$sent_http_location_masked" '
+#                        '"$http_referer_masked" "$http_user_agent"';
+#access_log  /dev/stdout  main;
+access_log off; # Handled by trafic
 
 server {
     server_name _;

--- a/frontend-image/oidc_protected.lua
+++ b/frontend-image/oidc_protected.lua
@@ -23,7 +23,6 @@ local res, err = require("resty.openidc").bearer_jwt_verify(opts)
 if err or not res or res.aud ~= acceptedAudience then
     ngx.status = 302
     if err then
-        ngx.log(ngx.INFO, "Redirect-Reason: "..err)
         ngx.header['Redirect-Reason'] = err
     elseif not res then
         ngx.log(ngx.INFO, "Redirect-Reason: no result")


### PR DESCRIPTION
accesslogger håndteres greit av traefik, så sletter unna den koden. Samtidig fjernes en duplikat logglinje når resty-openidc returnerer feil. Biblioteket har da selv også logget feilen, og dermed trenger ikke vi å gjøre det.