### PR TITLE
[KAIZEN-0] fix/404 missing

### DIFF
--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -89,6 +89,13 @@ server {
     }
 
 
+    # Static files are served directly with authenticating.
+    # Html is not included in list, since we want to autenticate user before loading the page
+    location ~* ^/${APP_NAME}(/.+\.css|js|jpe?g|gif|ico|png|xml|otf|ttf|eot|woff|svg|map|json)$ {
+        alias "/app-source/";
+        access_by_lua_file oidc_protected.lua;
+        try_files $1 =404;
+    }
     location = / {
         return 301 "${APP_NAME}/";
     }
@@ -97,15 +104,9 @@ server {
     }
     location "/${APP_NAME}/" {
         alias "/app-source/";
-        access_by_lua_file oidc_protected.lua;
-        try_files $uri @rewrites;
-    }
-
-    # No matching file, send to index.html as we expect it to handle this uri.
-    location @rewrites {
         index index.html;
+        access_by_lua_file oidc_protected.lua;
         try_files $uri $uri/ /index.html;
     }
-
     include /nginx-source/*.nginx;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -113,6 +113,22 @@ test('attempts to get frontend resource should result in login-flow', async () =
         'Cookie': idtoken
     });
     assertThat(pageLoadAfterLogin.statusCode, 200, '/frontend returns 200');
+    assertThat(pageLoadAfterLogin.body, contains('<!DOCTYPE html>'), '/frontend returns HTML')
+});
+
+test('static resources returns 302 login redirect, if not logged in', async () => {
+    const staticResource = await fetch('http://localhost:8083/frontend/static/css/index.css');
+    assertThat(staticResource.statusCode, 302, '/frontend returns 302');
+    assertThat(staticResource.body, notContains('<!DOCTYPE html>'), 'css-file is not HTML')
+});
+
+test('static resources returns 200 ok if logged in', async () => {
+    const tokens = await fetchJson('http://localhost:8080/oauth/token', {}, {});
+    const staticResource = await fetch('http://localhost:8083/frontend/static/css/index.css', {
+        'Cookie': `modia_ID_token=${tokens.body['id_token']};`
+    });
+    assertThat(staticResource.statusCode, 200, '/frontend returns 302');
+    assertThat(staticResource.body, notContains('<!DOCTYPE html>'), 'css-file is not HTML')
 });
 
 test('proxying to open endpoint when not logged in', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,15 @@ test('static resources returns 200 ok if logged in', async () => {
     assertThat(staticResource.body, notContains('<!DOCTYPE html>'), 'css-file is not HTML')
 });
 
+test('missing static resource returns 404 instead of fallback to index.html', async () => {
+    const tokens = await fetchJson('http://localhost:8080/oauth/token', {}, {});
+    const staticResource = await fetch('http://localhost:8083/frontend/static/css/missing.css',{
+        'Cookie': `modia_ID_token=${tokens.body['id_token']};`
+    });
+    assertThat(staticResource.statusCode, 404, '/frontend returns 404');
+    assertThat(staticResource.body, notContains('<!DOCTYPE html>'), 'css-file is not HTML')
+});
+
 test('proxying to open endpoint when not logged in', async () => {
     const openEndpointWithoutCookie = await fetchJson('http://localhost:8083/frontend/proxy/open-endpoint/data');
     assertThat(openEndpointWithoutCookie.statusCode, 200, '/frontend proxied to open endpoint');


### PR DESCRIPTION
* [KAIZEN-0] legge til tester som sjekker at filinnhold er riktig for statiske ressurser 995cd27

  Når man spørr etter en spesifik ressurs (e.g path har fil-extension), så har nettleseren en forventning til innholdet.

* [KAIZEN-0] fikse at man 404 om man spørr etter manglende ressurs 257c8a5

  Tidligere funksjonalitet gjorde at man fikk "200 OK index.html" som fallback,
  dette ble tolket av nettlesere som at alt var ok, og den prøvde derfor å parse innholdet som f.eks JS eller CSS.
  Denne parsingen feiler siden innholdet er HTML.
  Ønsker derfor heller at appen svarer med 404, slik at nettleseren forstår at noe gikk feil.

  Samtidig beholder vi funksjonaliteten som gjør at single-page-apps fortsatt kan bruke standard browser-routing.
