### PR TITLE
[PROD][KAIZEN-0] bedre håndtering av statiske ressurser

### DIFF
--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -26,10 +26,11 @@ map "${CSP_REPORT_ONLY}" $csp_enforce_directives {
     default   "${CSP_DIRECTIVES}";
 }
 
-log_format main         '[$time_local] '
-                        '"$request_masked" $status "$sent_http_location_masked" '
-                        '"$http_referer_masked" "$http_user_agent"';
-access_log  /dev/stdout  main;
+#log_format main         '[$time_local] '
+#                        '"$request_masked" $status "$sent_http_location_masked" '
+#                        '"$http_referer_masked" "$http_user_agent"';
+#access_log  /dev/stdout  main;
+access_log off; # Handled by trafic
 
 server {
     server_name _;


### PR DESCRIPTION
* [KAIZEN-0] legge til tester som sjekker at filinnhold er riktig for statiske ressurser 995cd27

  Når man spørr etter en spesifik ressurs (e.g path har fil-extension), så har nettleseren en forventning til innholdet.

* [KAIZEN-0] fikse at man 404 om man spørr etter manglende ressurs 257c8a5

  Tidligere funksjonalitet gjorde at man fikk "200 OK index.html" som fallback,
  dette ble tolket av nettlesere som at alt var ok, og den prøvde derfor å parse innholdet som f.eks JS eller CSS.
  Denne parsingen feiler siden innholdet er HTML.
  Ønsker derfor heller at appen svarer med 404, slik at nettleseren forstår at noe gikk feil.

  Samtidig beholder vi funksjonaliteten som gjør at single-page-apps fortsatt kan bruke standard browser-routing.
