### PR TITLE
[FAGSYSTEM-164333] sette max-age eksplisitt for refresh-token

### DIFF
--- a/frontend-image/default-app/index.html
+++ b/frontend-image/default-app/index.html
@@ -27,5 +27,8 @@ COPY build /app
 <p>
     Miljøvariabler &amp;{APP_NAME}: ${APP_NAME}
 </p>
+<p>
+    Miljøvariabler &amp;{APP_DUMMY_SECRET}: ${APP_DUMMY_SECRET}
+</p>
 </body>
 </html>

--- a/login-app/src/main/kotlin/no/nav/modialogin/features/LoginFlowFeature.kt
+++ b/login-app/src/main/kotlin/no/nav/modialogin/features/LoginFlowFeature.kt
@@ -94,7 +94,8 @@ class LoginFlowFeature(private val config: Config) {
         if (token.refreshToken != null) {
             call.respondWithCookie(
                 name = config.refreshTokenResolver,
-                value = token.refreshToken
+                value = token.refreshToken,
+                maxAgeInSeconds = 20 * 3600
             )
         }
         call.removeCookie(state)

--- a/test/nginx-env/testsecrets.env
+++ b/test/nginx-env/testsecrets.env
@@ -1,1 +1,1 @@
-DUMMY_SECRET_FOR_TESTING_ONLY="This is simply here to verify that env-loading of secrets work. Please ignore."
+APP_DUMMY_SECRET="This is simply here to verify that env-loading of secrets work. Please ignore."

--- a/test/test.js
+++ b/test/test.js
@@ -102,9 +102,11 @@ test('attempts to get frontend resource should result in login-flow', async () =
 
     assertThat(idtoken, startsWith('modia_ID_token'), '/modialogin/api/login sets modia_ID_token cookie');
     assertThat(idtoken, hasLengthGreaterThen(80), 'modia_ID_token has some content');
+    assertThat(idtoken, contains("Max-Age=3600;"), 'modia_ID_token is valid for 1 hour');
 
     assertThat(refreshtoken, startsWith('modia_refresh_token'), '/modialogin/api/login sets modia_refresh_token cookie');
     assertThat(refreshtoken, hasLengthGreaterThen(80), 'modia_refresh_token has some content');
+    assertThat(refreshtoken, contains("Max-Age=72000;"), 'modia_ID_token is valid for 24 hours');
 
     assertThat(removeStateCookie, startsWith(state), '/modialogin/api/login sets modia_ID_token cookie');
     assertThat(removeStateCookie, contains('01 Jan 1970'), '/modialogin/api/login removes state cookie');


### PR DESCRIPTION
* [KAIZEN-0] fikse visning av test-miljø-variabel 64d304a
  Bariabler som skal injectes inn i html etc må starte med `APP_` prefikset.
  Oppdatert test eksemplet slik at dette er tydelig via eksemplet

* [FAGSYSTEM-164333] sette max-age eksplisitt for refresh-token 123a1d7
  Uten å spesifisere levetiden til en cookie settes den til 1 time. Men refresh-tokenet skal kunne leve lengre enn dette, og setter 
derfor til 20 timer.

  Tokenet er bare gyldig så lenge man også har ett gyldig id-token, så det er derfor uproblematisk å utvide levetiden.
  Om man først blir logget ut, så vil man ikke kunne bruke refresh-tokenet for å hente ut ett nytt gyldig id-token.

  I teorien kan refresh-tokenet ha en arbitrær levetid, da dette er noe som konfigureres av identity-provideren (openAM i vårt tilfelle).
  Valget av 20 timer er basert på at man forventer at folk er inaktive en eller annen gang i løpet av perioden, og man kan sånn sett regne med at de må logge inn på nytt uansett.

  Scenarioet dette fikser er som følger;
  1. 12:00 bruker logger inn og får utstedt id-token og refresh-token, begge gyldige t.o.m 13:00
  2. 12:58 gjøres ett kall som sjekker gyldigheten til id-token, siden det er i ferd med å gå ut refreshes dette vha refresh-token (nå gyldig t.o.m 13:58).
  3. 13:56 id-token er på nytt i ferd med å gå ut, og vil igjen prøve å refreshe tokenet. Men nå er refresh-tokenet utløpt siden det ikke blir fornyet i pkt 2.

  Ved å utvide gyldigheten til refresh-tokenet, så vil det fortsatt være gyldig i situasjoner man når pkt 3 ovenfor, og man vil kunne refreshe id-tokenet en gang til.