### PR TITLE
[PROD][KAIZEN-0] legge til Referrer-Policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       # Just for testing, recommend omitting "CSP_REPORT_ONLY" which will default the value to "false"
       CSP_REPORT_ONLY: "true"
       CSP_DIRECTIVES: "default-src 'self'; script-src 'self';"
+      REFERRER_POLICY: "no-referrer"
     volumes:
       - ./test/nginx-env:/var/run/secrets/nais.io/vault/
       - ./test/nginx-proxy:/nginx

--- a/frontend-image/Dockerfile
+++ b/frontend-image/Dockerfile
@@ -16,10 +16,7 @@ COPY mask_log.lua         /usr/local/openresty/nginx/
 COPY start-nginx.sh       /usr/sbin/start-nginx
 
 RUN mkdir -p /app
-RUN mkdir -p /app-source
 RUN mkdir -p /nginx
-RUN mkdir -p /nginx-source
-RUN mkdir -p /usr/local/openresty
 
 # Just a small default-app that show how the image may be used.
 COPY default-app /app
@@ -28,10 +25,7 @@ EXPOSE 8080
 
 RUN addgroup -S apprunner && adduser -S apprunner -G apprunner
 RUN chown -R apprunner /app
-RUN chown -R apprunner /app-source
 RUN chown -R apprunner /nginx
-RUN chown -R apprunner /nginx-source
-RUN chown -R apprunner /usr/local/openresty
 RUN chown -R apprunner /etc/nginx/conf.d/
 RUN chown apprunner /usr/sbin/start-nginx
 RUN chmod +x /usr/sbin/start-nginx

--- a/frontend-image/README.md
+++ b/frontend-image/README.md
@@ -13,6 +13,7 @@ Docker-image som sikrer ressursene sine, og bruker en tilhørende `login-app` fo
 | AUTH_TOKEN_RESOLVER | Ja | Hvor appen kan forvente å finne ID_token. F.eks `ID_token` eller `header` |
 | CSP_DIRECTIVES | Nei | CSP-header som skal brukes, er default satt til `default-src: 'self'` | 
 | CSP_REPORT_ONLY | Nei | `true` eller `false`, styrer hvorvidt CSP skal være i `Report-Only` modus |
+| REFERRER_POLICY | Nei | Default `origin`. Forhindrer at url-path blir sendt som http header ved lenke klikk. [Les mer her](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples) |
 
 **NB** Om `AUTH_TOKEN_RESOLVER` settes til `header` vil applikasjonen forvente at access_token kommer via
 http-headeren `Authorization: Bearer <token>`.

--- a/frontend-image/nginx.nginx
+++ b/frontend-image/nginx.nginx
@@ -69,9 +69,10 @@ server {
     expires                 off;
     if_modified_since       off;
 
-    # Adding CSP header
+    # Adding security headers
     add_header              Content-Security-Policy-Report-Only $csp_report_directives;
     add_header              Content-Security-Policy $csp_enforce_directives;
+    add_header              Referrer-Policy "${REFERRER_POLICY}";
 
     location = "/${APP_NAME}/internal/isAlive" {
         default_type text/plan;

--- a/frontend-image/start-nginx.sh
+++ b/frontend-image/start-nginx.sh
@@ -39,6 +39,7 @@ export RESOLVER=$(cat /etc/resolv.conf | grep -v '^#' | grep -m 1 nameserver | a
 # Settings default environment variabels
 export CSP_DIRECTIVES="${CSP_DIRECTIVES:-default-src 'self';}"
 export CSP_REPORT_ONLY="${CSP_REPORT_ONLY:-false}"
+export REFERRER_POLICY="${REFERRER_POLICY:-origin}"
 
 
 echo "Startup: ${APP_NAME}:${APP_VERSION}"
@@ -79,6 +80,7 @@ declare -a ENV_VARIABLES=(
   '$RESOLVER'
   '$CSP_DIRECTIVES'
   '$CSP_REPORT_ONLY'
+  '$REFERRER_POLICY'
 )
 ALL_ENV_VARIABLES="${ENV_VARIABLES[*]}"
 # Checks all required variables are defined in environment

--- a/test/test.js
+++ b/test/test.js
@@ -130,6 +130,7 @@ test('static resources returns 200 ok if logged in', async () => {
         'Cookie': `modia_ID_token=${tokens.body['id_token']};`
     });
     assertThat(staticResource.statusCode, 200, '/frontend returns 302');
+    assertThat(staticResource.headers['referrer-policy'], 'no-referrer', '/frontend has referrer-policy');
     assertThat(staticResource.body, notContains('<!DOCTYPE html>'), 'css-file is not HTML')
 });
 


### PR DESCRIPTION
http-headeren instruerer nettleseren om hvordan den skal bruke `Referrer` headeren når noen klikker på en lenke.

Ved å sette den til default `origin` så vil bare `window.location.origin` (dvs domenet) bli satt i headeren. Man kan overstyre dette videre ved behov vha `REFERRER_POLICY` miljøvariablen
