### PR TITLE
[KAIZEN-0] mindre grace-periode for godkjenning av token.

### DIFF
--- a/common/src/main/kotlin/no/nav/modialogin/common/features/authfeature/AuthFeature.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/authfeature/AuthFeature.kt
@@ -7,24 +7,29 @@ import io.ktor.http.auth.*
 import io.ktor.server.application.*
 import io.ktor.server.auth.*
 import io.ktor.server.auth.jwt.*
+import io.ktor.util.date.*
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 class AuthFeature(private val config: Config) {
     val log: Logger = LoggerFactory.getLogger("AuthFeature")
-    val TEN_MINUTES: Long = 10 * 60 * 1000
+
     companion object {
         fun Application.installAuthFeature(config: Config) {
             AuthFeature(config).install(this)
         }
     }
+
     data class Config(
         var jwksUrl: String = "",
         val authTokenResolver: String,
         var acceptedAudience: String = ""
     )
+
     class PayloadPrincipal(val payload: Payload, val token: String) : Principal, Payload by payload
 
     fun install(application: Application) {
@@ -64,7 +69,7 @@ class AuthFeature(private val config: Config) {
             require(tokenAudience.contains(requiredAudience)) {
                 "Audience $requiredAudience not found in token, found: $tokenAudience"
             }
-            require(credentials.payload.doesNotExpireWithin(TEN_MINUTES)) {
+            require(credentials.payload.doesNotExpireWithin(2.minutes)) {
                 "Token expires soon, redirecting to login"
             }
         }.onFailure { log.error(it.message) }.getOrThrow()
@@ -76,8 +81,8 @@ class AuthFeature(private val config: Config) {
         return requireNotNull(call.request.cookies[idToken])
     }
 
-    private fun Payload.doesNotExpireWithin(withinMillies: Long): Boolean {
-        val shiftedExpirationTime = this.expiresAt.time - withinMillies
-        return System.currentTimeMillis() < shiftedExpirationTime
+    private fun Payload.doesNotExpireWithin(time: Duration): Boolean {
+        val expiry = this.expiresAt.time - time.inWholeMilliseconds
+        return getTimeMillis() < expiry
     }
 }


### PR DESCRIPTION
ISSO kan utstede token med kort levetid, som fører til at man havner i en login-loop.

ved å sette ned grace-perioden fra 10 til 2 minuter, så burde dette problemet bli mindre.
