### PR TITLE
[PROD][KAIZEN-0] mindre grace-periode for godkjenning av token.

### DIFF
--- a/common/src/main/kotlin/no/nav/modialogin/common/features/DefaultFeatures.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/DefaultFeatures.kt
@@ -9,12 +9,15 @@ import io.ktor.server.plugins.forwardedheaders.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import no.nav.modialogin.common.KtorServer.log
 import org.slf4j.event.Level
 
 object DefaultFeatures {
     val statusPageConfig: StatusPagesConfig.() -> Unit = {
         exception<Throwable> { call, cause ->
-            call.respond(HttpStatusCode.InternalServerError, cause.message ?: cause.localizedMessage)
+            val message = cause.message ?: cause.localizedMessage
+            log.error("Unhandled exception:", cause)
+            call.respond(HttpStatusCode.InternalServerError, message)
             throw cause
         }
     }

--- a/common/src/main/kotlin/no/nav/modialogin/common/features/authfeature/AuthFeature.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/authfeature/AuthFeature.kt
@@ -70,7 +70,7 @@ class AuthFeature(private val config: Config) {
                 "Audience $requiredAudience not found in token, found: $tokenAudience"
             }
             require(credentials.payload.doesNotExpireWithin(2.minutes)) {
-                "Token expires soon, redirecting to login"
+                "Token expires soon, redirecting to login: ${getTimeMillis()} < ${credentials.payload.expiresAt.time} - 2minutes"
             }
         }.onFailure { log.error(it.message) }.getOrThrow()
         return PayloadPrincipal(credentials.payload, getToken(this))


### PR DESCRIPTION
ISSO kan utstede token med kort levetid, som fører til at man havner i en login-loop.

ved å sette ned grace-perioden fra 10 til 2 minuter, så burde dette problemet bli mindre.
