### PR TITLE
[KAIZEN-0] setter cookies på rot-domene for host

### DIFF
--- a/common/src/main/kotlin/no/nav/modialogin/common/KotlinUtils.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/KotlinUtils.kt
@@ -32,4 +32,14 @@ object KotlinUtils {
 
         throw error ?: IllegalStateException("Retry failed without error")
     }
+
+    fun CharSequence.indicesOf(other: String, startIndex: Int = 0, ignoreCase: Boolean = false): List<Int> {
+        val indices = mutableListOf<Int>()
+        var index = this.indexOf(other, startIndex, ignoreCase)
+        while (index != -1) {
+            indices.add(index)
+            index = this.indexOf(other, index + 1, ignoreCase)
+        }
+        return indices
+    }
 }

--- a/common/src/main/kotlin/no/nav/modialogin/common/KtorUtils.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/KtorUtils.kt
@@ -3,6 +3,7 @@ package no.nav.modialogin.common
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
+import no.nav.modialogin.common.KotlinUtils.indicesOf
 import java.net.URLDecoder
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
@@ -19,7 +20,7 @@ object KtorUtils {
             Cookie(
                 name = name,
                 value = value,
-                domain = domain,
+                domain = cookieDomain(domain),
                 path = path,
                 maxAge = maxAgeInSeconds,
                 encoding = CookieEncoding.RAW,
@@ -28,6 +29,7 @@ object KtorUtils {
             )
         )
     }
+
     fun ApplicationCall.removeCookie(
         name: String,
         domain: String = request.host(),
@@ -35,11 +37,19 @@ object KtorUtils {
     ) {
         this.response.cookies.appendExpired(
             name = name,
-            domain = domain,
+            domain = cookieDomain(domain),
             path = path
         )
     }
 
     fun encode(value: String) = URLEncoder.encode(value, UTF_8)
     fun decode(value: String) = URLDecoder.decode(value, UTF_8)
+
+    fun cookieDomain(host: String): String {
+        val indices = host.indicesOf(".")
+        if (indices.size < 2) {
+            return host
+        }
+        return host.substring(indices.first() + 1)
+    }
 }


### PR DESCRIPTION
e.g for app.adeo.no vil cookies nå bli lagret på adeo.no, dette er tilsvarende hva hva OidcAuthFilter gjør i modiapersonoversikt-api/common-java-modules.

Dette gjøres for å unngå at browseren tar vare på to cookies med samme navn, men forskjellig domene. Da det blir "umulig" for andre systemer å vite hvilken cookie de skal forholde seg til. Ved å tvinge frem samme domene vil cookiene heller bli overskrevet.
