### PR TITLE
[PROD][KAIZEN-0] setter cookies på rot-domene for host

### DIFF
--- a/common/src/main/resources/no/nav/modialogin/common/logging/logback-default.xml
+++ b/common/src/main/resources/no/nav/modialogin/common/logging/logback-default.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <include resource="no/nav/modialogin/common/logging/logback-stdout-json.xml"/>
-<!--    <include resource="no/nav/modialogin/common/logging/logback-securelogs.xml"/>-->
+    <include resource="no/nav/modialogin/common/logging/logback-securelogs.xml"/>
 </included>


### PR DESCRIPTION
e.g for app.adeo.no vil cookies nå bli lagret på adeo.no, dette er tilsvarende hva hva OidcAuthFilter gjør i modiapersonoversikt-api/common-java-modules.

Dette gjøres for å unngå at browseren tar vare på to cookies med samme navn, men forskjellig domene. Da det blir "umulig" for andre systemer å vite hvilken cookie de skal forholde seg til. Ved å tvinge frem samme domene vil cookiene heller bli overskrevet.