### PR TITLE
[OPP-1490] Skifte pub fra docker til ghcr.io

### DIFF
--- a/.github/workflows/frontend-app-workflow.yml
+++ b/.github/workflows/frontend-app-workflow.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/modialogin-frontend:${{ github.sha }}
-  BETA_IMAGE: docker.pkg.github.com/${{ github.repository }}/modialogin-frontend:${{ github.sha }}-beta
+  IMAGE: ghcr.io/${{ github.repository }}/modialogin-frontend:${{ github.sha }}
+  BETA_IMAGE: ghcr.io/${{ github.repository }}/modialogin-frontend:${{ github.sha }}-beta
   CI: true
   TZ: Europe/Oslo
 jobs:
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} --password-stdin
+          echo ${GITHUB_TOKEN} | docker login ghcr.io -u ${GITHUB_REPOSITORY} --password-stdin
           docker build --tag ${BETA_IMAGE} frontend-app
           docker push ${BETA_IMAGE}
       - name: Publish image
@@ -64,6 +64,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} --password-stdin
+          echo ${GITHUB_TOKEN} | docker login ghcr.io -u ${GITHUB_REPOSITORY} --password-stdin
           docker build --tag ${IMAGE} frontend-app
           docker push ${IMAGE}

--- a/.github/workflows/frontend-image-workflow.yml
+++ b/.github/workflows/frontend-image-workflow.yml
@@ -19,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/frontend:${{ github.sha }}
-  BETA_IMAGE: docker.pkg.github.com/${{ github.repository }}/frontend:${{ github.sha }}-beta
+  IMAGE: ghcr.io/${{ github.repository }}/frontend:${{ github.sha }}
+  BETA_IMAGE: ghcr.io/${{ github.repository }}/frontend:${{ github.sha }}-beta
   CI: true
   TZ: Europe/Oslo
 jobs:
@@ -58,7 +58,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} --password-stdin
+          echo ${GITHUB_TOKEN} | docker login ghcr.io -u ${GITHUB_REPOSITORY} --password-stdin
           docker build --tag ${BETA_IMAGE} frontend-image
           docker push ${BETA_IMAGE}
       - name: Publish image
@@ -66,6 +66,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} --password-stdin
+          echo ${GITHUB_TOKEN} | docker login ghcr.io -u ${GITHUB_REPOSITORY} --password-stdin
           docker build --tag ${IMAGE} frontend-image
           docker push ${IMAGE}

--- a/.github/workflows/login-app-workflow.yml
+++ b/.github/workflows/login-app-workflow.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/modialogin:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/modialogin:${{ github.sha }}
   CI: true
   TZ: Europe/Oslo
 jobs:
@@ -86,7 +86,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          docker login ghcr.io -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
           docker build --tag ${IMAGE} login-app/
           docker push ${IMAGE}
   deploy-qa:

--- a/frontend-app/www/index.html
+++ b/frontend-app/www/index.html
@@ -16,7 +16,7 @@
     <b>Eksempel på Dockerfile:</b>
 </p>
 <pre>
-FROM docker.pkg.github.com/navikt/modialogin/frontend:ecd23b296051ce8d436025e242b79521d9244b32
+FROM ghcr.io/navikt/modialogin/frontend:ecd23b296051ce8d436025e242b79521d9244b32
 # Hvor "build" mappen inneholder filene du ønsker skal hostes.
 COPY build /www
 </pre>

--- a/frontend-image/default-app/index.html
+++ b/frontend-image/default-app/index.html
@@ -15,7 +15,7 @@
     <b>Eksempel på Dockerfile:</b>
 </p>
 <pre>
-FROM docker.pkg.github.com/navikt/modialogin/frontend:ecd23b296051ce8d436025e242b79521d9244b32
+FROM ghcr.io/navikt/modialogin/frontend:ecd23b296051ce8d436025e242b79521d9244b32
 # Hvor "build" mappen inneholder filene du ønsker skal hostes.
 COPY build /app
 </pre>


### PR DESCRIPTION
docker.pkg.github.com er deprecated, erstattet med ghcr.io