### PR TITLE
div/proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ start:
 start-silent:
 	docker-compose up --build -d
 
+start-idea:
+	docker-compose up -d echo-server
+
 stop:
 	docker-compose down --remove-orphans
 

--- a/common/src/main/kotlin/no/nav/modialogin/common/KtorUtils.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/KtorUtils.kt
@@ -3,6 +3,7 @@ package no.nav.modialogin.common
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.request.*
+import no.nav.modialogin.common.KotlinUtils.getProperty
 import no.nav.modialogin.common.KotlinUtils.indicesOf
 import no.nav.personoversikt.crypto.Crypter
 import org.slf4j.LoggerFactory
@@ -12,6 +13,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 object KtorUtils {
     private val log = LoggerFactory.getLogger("KtorUtils")
+    private val isLocalhostDevelopment = getProperty("IS_LOCALHOST_DEV")?.toBoolean() ?: false
     fun ApplicationCall.respondWithCookie(
         name: String,
         value: String,
@@ -34,7 +36,7 @@ object KtorUtils {
                 path = path,
                 maxAge = maxAgeInSeconds,
                 encoding = encoding,
-                secure = true,
+                secure = !isLocalhostDevelopment,
                 httpOnly = true
             )
         )

--- a/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
@@ -6,12 +6,14 @@ import io.ktor.server.auth.*
 import io.ktor.server.metrics.micrometer.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.micrometer.core.instrument.Clock
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.prometheus.client.CollectorRegistry
 import no.nav.modialogin.common.NaisState
 
 object Metrics {
-    val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+    val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM)
 }
 interface WhoAmIPrincipal : Principal {
     val description: String

--- a/frontend-app/build.gradle.kts
+++ b/frontend-app/build.gradle.kts
@@ -5,6 +5,7 @@ val ktor_version: String by project
 val logback_version: String by project
 val logstash_version: String by project
 val java_common_version: String by project
+val prometheus_version: String by project
 val modia_common_version: String by project
 val autokonfig_version: String by project
 val junit_version: String by project
@@ -33,6 +34,7 @@ dependencies {
     implementation("dev.nohus:AutoKonfig:$autokonfig_version")
     implementation("no.nav.common:token-client:$java_common_version")
     implementation("no.nav.personoversikt:crypto:$modia_common_version")
+    implementation("io.micrometer:micrometer-registry-prometheus:$prometheus_version")
 
     testImplementation("org.junit.jupiter:junit-jupiter:$junit_version")
 }

--- a/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
+++ b/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
@@ -9,6 +9,8 @@ import no.nav.modialogin.auth.AzureAdConfig
 import java.util.*
 
 fun main() {
+    System.setProperty("IS_LOCALHOST_DEV", "true")
+
     System.setProperty("APP_NAME", "frontend")
     System.setProperty("APP_VERSION", "localhost")
     System.setProperty("IDP_DISCOVERY_URL", "http://localhost:8080/openam/.well-known/openid-configuration")
@@ -24,7 +26,7 @@ fun main() {
     System.setProperty("OUTSIDE_DOCKER", "true")
     System.setProperty("SECRET", "some secret")
 
-//    setupAzureAdEnv()
+    setupAzureAdEnv()
 
     startApplication()
 }

--- a/login-app/src/test/kotlin/no/nav/modialogin/LocalLoginApp.kt
+++ b/login-app/src/test/kotlin/no/nav/modialogin/LocalLoginApp.kt
@@ -1,6 +1,8 @@
 package no.nav.modialogin
 
 fun main() {
+    System.setProperty("IS_LOCALHOST_DEV", "true")
+
     System.setProperty("APP_NAME", "modialogin")
     System.setProperty("APP_VERSION", "localhost")
     System.setProperty("IDP_DISCOVERY_URL", "http://localhost:8080/openam/.well-known/openid-configuration")


### PR DESCRIPTION
- [KAIZEN-0] legge til metrikk for token-bytte med azure ad
- [KAIZEN-0] oppdatert proxy til å sende med innhold og headere
- [KAIZEN-0] benytte standard metrics-collector
- [KAIZEN-0] legge til makefile-target for starting av echo-server
- [KAIZEN-0] benytter unsecure cookies ved kjøring lokalt
