### PR TITLE
fix/refresh token callid

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation("io.ktor:ktor-server-content-negotiation:$ktor_version")
     implementation("io.ktor:ktor-server-forwarded-header:$ktor_version")
     implementation("io.ktor:ktor-server-call-logging:$ktor_version")
+    implementation("io.ktor:ktor-server-call-id:$ktor_version")
     implementation("io.ktor:ktor-server-metrics-micrometer:$ktor_version")
     implementation("io.ktor:ktor-server-auth:$ktor_version")
     implementation("io.ktor:ktor-serialization:$ktor_version")

--- a/common/src/main/kotlin/no/nav/modialogin/common/KotlinUtils.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/KotlinUtils.kt
@@ -1,6 +1,8 @@
 package no.nav.modialogin.common
 
 import kotlinx.coroutines.delay
+import org.slf4j.MDC
+import java.util.*
 import kotlin.time.Duration
 
 object KotlinUtils {
@@ -41,5 +43,10 @@ object KotlinUtils {
             index = this.indexOf(other, index + 1, ignoreCase)
         }
         return indices
+    }
+
+    const val callIdProperty = "callId"
+    fun callId(): String {
+        return MDC.get(callIdProperty) ?: UUID.randomUUID().toString()
     }
 }

--- a/common/src/main/kotlin/no/nav/modialogin/common/features/DefaultFeatures.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/DefaultFeatures.kt
@@ -3,12 +3,14 @@ package no.nav.modialogin.common.features
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
+import io.ktor.server.plugins.callid.*
 import io.ktor.server.plugins.callloging.*
 import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.forwardedheaders.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
+import no.nav.modialogin.common.KotlinUtils.callIdProperty
 import no.nav.modialogin.common.KtorServer.log
 import org.slf4j.event.Level
 import java.util.*
@@ -31,11 +33,16 @@ object DefaultFeatures {
             hostHeaders.clear()
             forHeaders.clear()
         }
+        install(CallId) {
+            header(HttpHeaders.XCorrelationId)
+            verify { it.isNotEmpty() }
+            generate { UUID.randomUUID().toString() }
+        }
         install(CallLogging) {
             level = Level.INFO
             format(::logFormat)
             filter { call -> call.request.path().contains("/internal/").not() }
-            mdc("callId") { UUID.randomUUID().toString() }
+            callIdMdc(callIdProperty)
         }
     }
 

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/auth/OidcClient.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/auth/OidcClient.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import no.nav.modialogin.common.*
+import no.nav.modialogin.common.KotlinUtils.callId
 import java.net.URL
 import kotlin.time.Duration.Companion.seconds
 
@@ -44,6 +45,7 @@ class OidcClient(val config: Config) {
             json()
             defaultRequest {
                 header(HttpHeaders.CacheControl, "no-cache")
+                header(HttpHeaders.XCorrelationId, callId())
             }
         }
     }

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/authfeature/DelegatedRefreshClient.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/authfeature/DelegatedRefreshClient.kt
@@ -3,13 +3,13 @@ package no.nav.modialogin.features.authfeature
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.apache.*
-import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import no.nav.modialogin.common.KotlinUtils.callId
 import no.nav.modialogin.common.KtorServer.tjenestekallLogger
+import no.nav.modialogin.common.json
 import java.net.URL
 
 class DelegatedRefreshClient(url: String) {
@@ -21,13 +21,11 @@ class DelegatedRefreshClient(url: String) {
     private class RefreshIdTokenRequest(val refreshToken: String)
 
     private val client = HttpClient(Apache) {
-        install(ContentNegotiation) {
-            json(
-                Json {
-                    ignoreUnknownKeys = true
-                    isLenient = true
-                }
-            )
+        json()
+        defaultRequest {
+            headers {
+                append(HttpHeaders.XCorrelationId, callId())
+            }
         }
     }
 

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/BFFProxyFeature.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/BFFProxyFeature.kt
@@ -2,6 +2,7 @@ package no.nav.modialogin.features.bffproxyfeature
 
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -16,6 +17,7 @@ import io.ktor.utils.io.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
+import no.nav.modialogin.common.KotlinUtils
 import no.nav.modialogin.common.KtorServer.log
 import no.nav.modialogin.common.Templating
 import java.net.URL
@@ -52,6 +54,11 @@ object BFFProxyFeature {
         val (responseHandler, requestHandler) = bffProxy.parseDirectives(config.rewriteDirectives)
         val client = HttpClient(Apache) {
             followRedirects = false
+            defaultRequest {
+                headers {
+                    append(HttpHeaders.XCorrelationId, KotlinUtils.callId())
+                }
+            }
         }
 
         handle {


### PR DESCRIPTION
- [KAIZEN-0] fjerne refresh-token om refreshing feiler
- [KAIZEN-0] sende med callId ved http-kall til modialogin
