### PR TITLE
[KAIZEN-0] legge til muligheten for å skru av azuread innlogging

### DIFF
--- a/frontend-app/README.md
+++ b/frontend-app/README.md
@@ -9,7 +9,7 @@ Docker-image som sikrer ressursene sine, og bruker en tilhørende `login-app` fo
 | APP_VERSION            | Ja    | Version av applikasjonen. Er bare synlig på selftest-siden                                                                                                                             |
 | IDP_DISCOVERY_URL      | Ja    | Url til discovery-url for idp (typisk noe som slutter på .well-known/openid-configuration)                                                                                             |
 | IDP_CLIENT_ID          | Ja    | Systembrukernavn for autentisering mot idp                                                                                                                                             |
-| IDP_ISSUER             | Ja    | Issuer for token, e.g: `https://your.ipd.no:443/oauth2`                                                                                                                           |
+| IDP_ISSUER             | Ja    | Issuer for token, e.g: `https://your.ipd.no:443/oauth2`                                                                                                                                |
 | DELEGATED_LOGIN_URL    | Ja    | Url til `login-app`, e.g `http://domain.nav.no/loginapp/api/start`                                                                                                                     |
 | DELEGATED_REFRESH_URL  | Ja    | Url til `login-app` for refreshing av token, e.g `http://domain.nav.no/loginapp/api/refresh`                                                                                           |
 | AUTH_TOKEN_RESOLVER    | Nei   | Hvor appen kan forvente å finne ID_token. F.eks `ID_token` eller `header`, default: `ID_token`                                                                                         |
@@ -17,6 +17,7 @@ Docker-image som sikrer ressursene sine, og bruker en tilhørende `login-app` fo
 | CSP_DIRECTIVES         | Nei   | CSP-header som skal brukes, default: `default-src: 'self'`                                                                                                                             | 
 | CSP_REPORT_ONLY        | Nei   | `true` eller `false`, styrer hvorvidt CSP skal være i `Report-Only` modus, default: `false`                                                                                            |
 | REFERRER_POLICY        | Nei   | Forhindrer at url-path blir sendt som http header ved lenke klikk. [Les mer her](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples), Default `origin` |
+| DISABLE_AZURE_AD       | Nei   | Forhindrer at AzureAd konfigurasjon blir tatt i bruk. Kan brukes når man ønsker å registere en applikasjon i AzureAd uten at tilgangskontrollen slår inn. Default: `false`             |
 
 
 **NB** Om `AUTH_TOKEN_RESOLVER` settes til `header` vil applikasjonen forvente at access_token kommer via

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/auth/AzureAdConfig.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/auth/AzureAdConfig.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import no.nav.common.token_client.utils.env.AzureAdEnvironmentVariables
-import no.nav.modialogin.common.KotlinUtils
+import no.nav.modialogin.common.KotlinUtils.getProperty
+import no.nav.modialogin.common.KotlinUtils.requireProperty
 import no.nav.modialogin.common.KtorServer.log
 
 class AzureAdConfig(
@@ -37,21 +38,22 @@ class AzureAdConfig(
 
     companion object {
         fun load(): AzureAdConfig? {
+            val disableAzureAd = getProperty("DISABLE_AZURE_AD")?.toBooleanStrictOrNull() ?: false
+            if (disableAzureAd) {
+                return null
+            }
+
             return kotlin.runCatching {
-                val clientId = KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_CLIENT_ID)
-                val clientSecret = KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_CLIENT_SECRET)
-                val tenantId = KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_TENANT_ID)
-                val appJWK = KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_JWK)
-                val preAuthorizedApps =
-                    KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_PRE_AUTHORIZED_APPS)
-                val wellKnownUrl = KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_APP_WELL_KNOWN_URL)
-                val openidConfigIssuer =
-                    KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_ISSUER)
-                val openidConfigJWKSUri =
-                    KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_JWKS_URI)
-                val openidConfigTokenEndpoint =
-                    KotlinUtils.requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_TOKEN_ENDPOINT)
-                val encryptionSecret = KotlinUtils.getProperty("COOKIE_ENCRYPTION_KEY")
+                val clientId = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_CLIENT_ID)
+                val clientSecret = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_CLIENT_SECRET)
+                val tenantId = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_TENANT_ID)
+                val appJWK = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_JWK)
+                val preAuthorizedApps = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_PRE_AUTHORIZED_APPS)
+                val wellKnownUrl = requireProperty(AzureAdEnvironmentVariables.AZURE_APP_WELL_KNOWN_URL)
+                val openidConfigIssuer = requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_ISSUER)
+                val openidConfigJWKSUri = requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_JWKS_URI)
+                val openidConfigTokenEndpoint = requireProperty(AzureAdEnvironmentVariables.AZURE_OPENID_CONFIG_TOKEN_ENDPOINT)
+                val encryptionSecret = getProperty("COOKIE_ENCRYPTION_KEY")
 
                 AzureAdConfig(
                     clientId = clientId,


### PR DESCRIPTION
Kan brukes når man ønsker å registere en applikasjon i AzureAd uten at tilgangskontrollen slår inn.
