### PR TITLE
[KAIZEN-0] gjøre det mulig å styre proxy-fil fra env-vars

### DIFF
--- a/frontend-app/README.md
+++ b/frontend-app/README.md
@@ -17,6 +17,7 @@ Docker-image som sikrer ressursene sine, og bruker en tilhørende `login-app` fo
 | CSP_DIRECTIVES         | Nei   | CSP-header som skal brukes, default: `default-src: 'self'`                                                                                                                             | 
 | CSP_REPORT_ONLY        | Nei   | `true` eller `false`, styrer hvorvidt CSP skal være i `Report-Only` modus, default: `false`                                                                                            |
 | REFERRER_POLICY        | Nei   | Forhindrer at url-path blir sendt som http header ved lenke klikk. [Les mer her](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#examples), Default `origin` |
+| PROXY_CONFIG_FILE      | Nei   | Plassering av konfigurasjons-filen for proxy-oppsett. Default `/proxy-config.json`                                                                                                                 |
 | DISABLE_AZURE_AD       | Nei   | Forhindrer at AzureAd konfigurasjon blir tatt i bruk. Kan brukes når man ønsker å registere en applikasjon i AzureAd uten at tilgangskontrollen slår inn. Default: `false`             |
 
 

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
@@ -9,7 +9,7 @@ import no.nav.modialogin.common.KtorServer.log
 import no.nav.modialogin.features.bffproxyfeature.BFFProxyFeature.ProxyConfig
 import java.io.File
 
-class FrontendAppConfig(proxyConfigFile: File) {
+class FrontendAppConfig {
     val appName by StringSetting()
     val appVersion by StringSetting()
     val idpDiscoveryUrl by StringSetting()
@@ -23,9 +23,12 @@ class FrontendAppConfig(proxyConfigFile: File) {
     val cspDirectives by StringSetting(default = "default src 'self'")
     val referrerPolicy by StringSetting(default = "origin")
     val exposedPort by IntSetting(default = 8080)
+    val proxyConfigFile by StringSetting(default = "/proxy-config.json")
     val proxyConfig: List<ProxyConfig> by lazy {
-        if (proxyConfigFile.exists()) {
-            val content = proxyConfigFile.readText()
+        val file = File(proxyConfigFile)
+        if (file.exists()) {
+            log.info("Loading proxy-config from $proxyConfigFile")
+            val content = file.readText()
             Json
                 .runCatching {
                     decodeFromString<List<ProxyConfig>>(content)

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/Main.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/Main.kt
@@ -21,7 +21,6 @@ import no.nav.modialogin.features.bffproxyfeature.BFFProxyFeature.installBFFProx
 import no.nav.modialogin.features.oauthfeature.OAuthAuthProvider
 import no.nav.modialogin.features.oauthfeature.OAuthFeature
 import no.nav.modialogin.features.oauthfeature.OAuthFeature.Companion.installOAuthRoutes
-import java.io.File
 
 fun main() {
     startApplication()
@@ -29,10 +28,9 @@ fun main() {
 
 fun startApplication() {
     val outsideDocker = getProperty("OUTSIDE_DOCKER") == "true"
-    val proxyConfigFile = if (outsideDocker) "./frontend-app/proxy-config/proxy-config.json" else "/proxy-config.json"
     val staticFilesRootFolder = if (outsideDocker) "./frontend-app/www" else "/www"
 
-    val appConfig = FrontendAppConfig(File(proxyConfigFile))
+    val appConfig = FrontendAppConfig()
     val port = if (outsideDocker) appConfig.exposedPort else 8080
     log.info("Starting app: $port")
 

--- a/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
+++ b/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
@@ -24,6 +24,7 @@ fun main() {
     System.setProperty("REFERRER_POLICY", "no-referrer")
     System.setProperty("EXPOSED_PORT", "8083")
     System.setProperty("OUTSIDE_DOCKER", "true")
+    System.setProperty("PROXY_CONFIG_FILE", "./frontend-app/proxy-config/proxy-config.json")
     System.setProperty("SECRET", "some secret")
 
     setupAzureAdEnv()


### PR DESCRIPTION
kan brukes for å enklere ha forskjellig proxy-oppsett i ulike miljø
