### PR TITLE
[KAIZEN-0] Maskere ut personnummer i proxy

### DIFF
--- a/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
@@ -21,6 +21,7 @@ interface WhoAmIPrincipal : Principal {
 
 fun Application.installNaisFeature(appname: String, appversion: String, config: NaisState, selftestAttributes: Map<String, Any> = emptyMap()) {
     install(MicrometerMetrics) {
+        distinctNotRegisteredRoutes = false
         registry = Metrics.registry
     }
     val selftestContent: String = buildString {

--- a/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
+++ b/common/src/main/kotlin/no/nav/modialogin/common/features/NaisFeature.kt
@@ -54,7 +54,7 @@ fun Application.installNaisFeature(appname: String, appversion: String, config: 
                     call.respondText(selftestContent)
                 }
                 get("metrics") {
-                    call.respond(Metrics.registry.scrape())
+                    call.respondText(Metrics.registry.scrape())
                 }
 
                 authenticate {

--- a/test/http-fetch.js
+++ b/test/http-fetch.js
@@ -56,7 +56,18 @@ function fetchJson(url, headers, body) {
         });
 }
 
+const fetchText = (url, headers, body) => {
+    return fetch(url, headers, body).then(({ statusCode, statusMessage, redirectURI, body }) => {
+        if (body) {
+            return { statusCode, statusMessage, redirectURI, body: body.toString() }
+        } else {
+            throw new Error(`${url} did not return text, statuscode: ${statusCode} body: ${body}`);
+        }
+    })
+}
+
 module.exports = {
     fetch,
-    fetchJson
+    fetchJson,
+    fetchText
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
-const { test, testonly, assertThat, verify, setup, retry, equals, isDefined, isNotDefined, startsWith, contains, notContains, hasLengthGreaterThen } = require('./test-lib');
-const { fetch, fetchJson } = require('./http-fetch');
+const { test, assertThat, verify, setup, retry, equals, isDefined, isNotDefined, startsWith, contains, notContains, hasLengthGreaterThen } = require('./test-lib');
+const { fetch, fetchJson, fetchText } = require('./http-fetch');
 
 setup('oidc-stub is running', retry({ retry: 10, interval: 2}, async () => {
     const oidcConfig = await fetchJson('http://localhost:8080/openam/.well-known/openid-configuration');
@@ -381,3 +381,11 @@ test('referrer-policy is added to response', async () => {
     });
     assertThat(page.headers['referrer-policy'], 'no-referrer', '/frontend has referrer-policy');
 });
+
+test('personal number is not scraped by Micrometer when proxy is used and the user is not logged in', async () => {
+    const personalNumber = '12345678910'
+
+    await fetch(`http://localhost:8083/frontend/proxy/${personalNumber}`)
+    const scrapeDump = await fetchText(`http://localhost:8083/frontend/internal/metrics`)
+    assertThat(scrapeDump.body, notContains(personalNumber), '/frontend masks personal number')
+})


### PR DESCRIPTION
Proxy kall som ble redirected som inneholdt personnummer i urlen, ble lagret av Micrometer. Det er nå fjernet ved at proxy kall defaulter til n/a. I tillegg returnerer nå metrics endepunktet de scrapete loggene som tekst.