### PR TITLE
[HOTFIX][KAIZEN-0] skru opp nginx-ingress-controller sin maks størrelse for headere

### DIFF
--- a/.nais/preprod.yml
+++ b/.nais/preprod.yml
@@ -5,6 +5,8 @@ metadata:
   namespace: personoversikt
   labels:
     team: personoversikt
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
 spec:
   image: {{image}}
   port: 8080

--- a/.nais/prod.yml
+++ b/.nais/prod.yml
@@ -5,6 +5,8 @@ metadata:
   namespace: personoversikt
   labels:
     team: personoversikt
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
 spec:
   image: {{image}}
   port: 8080


### PR DESCRIPTION
Når både ISSO og AzureAd er skrudd på kan Cookie headeren bli stor nok til at man overskrider nginx sin standard godkjente verdi.

For å sikre at modialogin også greier å ta imot alle cookies skrur vi derfor opp godkjent størrelse her også
