### PR TITLE
[PROD] [KAIZEN-0] splitte transform-plugin til to plugins

### DIFF
--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/HostStaticFilesFeature.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/HostStaticFilesFeature.kt
@@ -53,16 +53,16 @@ class HostStaticFilesFeature(val config: Config) {
                 DefaultFeatures.statusPageConfig(this)
             }
 
+            install(TemplatingFeature.Plugin) {
+                templatingEngine = templateEngine
+            }
             routing {
                 authenticate {
                     static(config.appname) {
+                        install(TemplatingFeature.EnableRouteTransform)
                         staticRootFolder = File("/tmp/www")
                         files(".")
                         default("index.html")
-                        install(TemplatingFeature.Plugin) {
-                            contextpath = config.appname
-                            templatingEngine = templateEngine
-                        }
                     }
                 }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -357,7 +357,7 @@ test('environments variables are injected into nginx config', async () => {
 
 test('environments and unleash variables are injected into html config', async () => {
     const tokens = await fetchJson('http://localhost:8080/openam/oauth/token', {}, {});
-    const page = await fetch('http://localhost:8083/frontend/', {
+    const page = await fetch('http://localhost:8083/frontend/and/some/path', {
         'Cookie': `modia_ID_token=${tokens.body['id_token']};`
     });
     assertThat(page.body, contains('&#36;env{APP_NAME}: frontend'), 'Page contains environmentvariable value')


### PR DESCRIPTION
Plugin som gjør transformasjonen er lagt til applikasjonsnivå for å fange opp alle responser.

For å unngå at requester utenfor statics hosting blir fanget opp er det lagt til en egen route-plugin som enabler transformering.

På denne måten vil ikke kall som treffer bff-proxy bli utsatt for transformering