### PR TITLE
[KAIZEN-0] legge til oppsett for bruk av CDN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ start-silent:
 	docker compose up --build -d
 
 start-idea:
-	docker compose up -d echo-server redis
+	docker compose up -d echo-server redis cdnstub
 
 stop:
 	docker compose down --remove-orphans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
       REFERRER_POLICY: "no-referrer"
       UNLEASH_API_URL: "http://oidc-stub:8080/unleash"
       EXPOSED_PORT: '8083'
+      CDN_BUCKET_URL: "http://cdnstub:80/cdn/frontend/"
       NAIS_CLUSTER_NAME: 'dev-local'
       IS_LOCALHOST_DEV: "true"
     volumes:
@@ -106,3 +107,9 @@ services:
       - '6379:6379'
     environment:
       REDIS_PASSWORD: "password123"
+  cdnstub:
+    image: httpd:2.4-alpine
+    volumes:
+      - ./frontend-app/www:/usr/local/apache2/htdocs/cdn/frontend
+    ports:
+      - 8091:80

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
@@ -31,6 +31,7 @@ class FrontendAppConfig {
             .build()
         DefaultUnleash(config)
     }
+    val cdnBucketUrl: String? = getProperty("CDN_BUCKET_URL")
     val proxyConfig: List<ProxyConfig> = readProxyConfig()
 
     private fun readProxyConfig(): List<ProxyConfig> {

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/Main.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/Main.kt
@@ -19,6 +19,7 @@ import no.nav.modialogin.features.csp.CSPFeature
 import no.nav.modialogin.features.oauthfeature.OAuthAuthProvider
 import no.nav.modialogin.features.oauthfeature.OAuthFeature
 import no.nav.modialogin.features.oauthfeature.OAuthFeature.Companion.installOAuthRoutes
+import no.nav.modialogin.features.staticFilesFromCDN
 
 fun main() {
     startApplication()
@@ -105,13 +106,21 @@ fun startApplication() {
                 }
             }
         )
-        installHostStaticFilesFeature(
-            HostStaticFilesFeature.Config(
-                appname = config.appName,
-                rootFolder = staticFilesRootFolder,
+        if (config.cdnBucketUrl != null) {
+            staticFilesFromCDN(
+                contextpath = config.appName,
+                cdnUrl = config.cdnBucketUrl,
                 unleash = config.unleash
             )
-        )
+        } else {
+            installHostStaticFilesFeature(
+                HostStaticFilesFeature.Config(
+                    appname = config.appName,
+                    rootFolder = staticFilesRootFolder,
+                    unleash = config.unleash
+                )
+            )
+        }
         installBFFProxy(
             BFFProxyFeature.Config(
                 appName = config.appName,

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/CDN.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/CDN.kt
@@ -1,0 +1,105 @@
+package no.nav.modialogin.features
+
+import io.getunleash.Unleash
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.apache.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.http.content.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import no.nav.modialogin.common.*
+import no.nav.modialogin.features.csp.CSPFeature
+import no.nav.modialogin.features.templatingfeature.TemplatingFeature
+import java.io.File
+
+
+private const val pathParameterName = "static-content-path-parameter"
+fun Application.staticFilesFromCDN(
+    contextpath: String,
+    cdnUrl: String,
+    unleash: Unleash? = null
+) {
+    val templateSources = listOfNotNull(
+        Templating.EnvSource,
+        CSPFeature.NonceSource,
+        if (unleash != null) UnleashTemplateSource.create(unleash) else null
+    ).toTypedArray()
+    val templateEngine = TemplatingEngine(*templateSources)
+
+    if (tmpDir.exists()) {
+        tmpDir.deleteRecursively()
+        tmpDir.mkdirs()
+    }
+
+    install(IgnoreTrailingSlash)
+    install(TemplatingFeature.Plugin) {
+        templatingEngine = templateEngine
+    }
+
+    routing {
+        route(contextpath) {
+            install(TemplatingFeature.EnableRouteTransform)
+            get("{$pathParameterName...}") {
+                val relativePath = call.parameters.getAll(pathParameterName)?.joinToString(File.separator) ?: return@get
+                call.respondWithFile(cdnUrl, relativePath)
+
+            }
+        }
+    }
+}
+
+private val tmpDir = File("/tmp/cdn")
+private val cdnClient = HttpClient(Apache) {
+    useProxy()
+    logging()
+    defaultRequest {
+        header(HttpHeaders.CacheControl, "no-cache")
+    }
+}
+private val statusMap: MutableMap<String, HttpStatusCode> = mutableMapOf()
+
+private suspend fun ApplicationCall.respondWithFile(cdnUrl: String, path: String) {
+    val errorStatus = statusMap[path]
+    if (errorStatus != null) {
+        respond(errorStatus, errorStatus.description)
+        return
+    }
+
+    val file = tmpDir.resolve(path)
+    if (file.extension.isBlank()) {
+        // TODO how to ensure that the index.html is "fresh"
+        // MAYBE use redis to cache files from previous deploys instead? CDN has a 15 minute delay while invaliding its cache
+        respondWithFile(cdnUrl, "index.html")
+    } else if (file.isFile) {
+        respond(LocalFileContent(file, ContentType.defaultForFile(file)))
+    } else if (!file.exists()) {
+        withContext(Dispatchers.IO) {
+            try {
+                KtorServer.log.info("Fetching resource from $cdnUrl/$path")
+                val response = cdnClient.get("$cdnUrl/$path")
+                if (!response.status.isSuccess()) {
+                    statusMap[path] = response.status
+                    respond(response.status, response.status.description)
+                } else {
+                    val content = response.body<ByteArray>()
+
+                    file.parentFile.mkdirs()
+                    file.createNewFile()
+                    file.writeBytes(content)
+
+                    respond(LocalFileContent(file, ContentType.defaultForFile(file)))
+                }
+            } catch (e: Throwable) {
+                KtorServer.log.error("Error while fetching $path from CDN", e)
+                respond(status = HttpStatusCode.InternalServerError, e.message ?: "Unknown error")
+            }
+        }
+
+    }
+}

--- a/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
+++ b/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
@@ -28,6 +28,7 @@ fun main() {
     System.setProperty("UNLEASH_API_URL", "http://localhost:8080/unleash")
     System.setProperty("REDIS_HOST", "localhost")
     System.setProperty("REDIS_PASSWORD", "password123")
+    System.setProperty("CDN_BUCKET_URL", "http://localhost:8091/cdn/frontend/")
     System.setProperty("SECRET", "some secret")
 
     setupAzureAdEnv()


### PR DESCRIPTION
frontend-plattformen gjør det enklere å laste opp filer til cdn ved deploy, og gjør at det er mindre behov for å oppdatere appen.
