### PR TITLE
[KAIZEN-0] lage en felles connectionpool til redis

### DIFF
--- a/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/FrontendAppConfig.kt
@@ -1,6 +1,5 @@
 package no.nav.modialogin
 
-import com.nimbusds.jose.jwk.JWK
 import io.getunleash.DefaultUnleash
 import io.getunleash.Unleash
 import io.getunleash.util.UnleashConfig
@@ -98,14 +97,13 @@ class AzureAdConfig(
     val clientId: String,
     val clientSecret: String,
     val tenantId: String,
-    appJWK: String,
+    val appJWK: String,
     preAuthorizedApps: String,
     val wellKnownUrl: String,
     val openidConfigIssuer: String,
     val openidConfigJWKSUri: String,
     val openidConfigTokenEndpoint: String,
 ) {
-    val appJWK: JWK = JWK.parse(appJWK)
     val preAuthorizedApps = Json.decodeFromString<List<PreauthorizedApp>>(preAuthorizedApps)
 
     @Serializable

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/authfeature/SessionCache.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/authfeature/SessionCache.kt
@@ -7,16 +7,19 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.builtins.serializer
 import no.nav.modialogin.persistence.RedisPersistence
+import no.nav.modialogin.utils.AuthJedisPool
 import no.nav.modialogin.utils.CaffeineTieredCache
-import no.nav.modialogin.utils.RedisUtils
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
-class SessionCache(private val oidcClient: OidcClient) {
+class SessionCache(
+    private val oidcClient: OidcClient,
+    redis: AuthJedisPool,
+) {
     private val cache = CaffeineTieredCache(
         persistence = RedisPersistence(
             scope = "session",
-            redisPool = RedisUtils.pool,
+            redisPool = redis,
             keySerializer = String.serializer(),
             valueSerializer = TokenPrincipal.serializer()
         ),

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/BFFProxy.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/BFFProxy.kt
@@ -3,20 +3,17 @@ package no.nav.modialogin.features.bffproxyfeature
 import io.ktor.client.request.*
 import io.ktor.server.application.*
 import io.ktor.util.pipeline.*
-import no.nav.modialogin.Logging.log
-import no.nav.modialogin.features.bffproxyfeature.directives.AADOnBehalfOfDirectiveSpecification
-import no.nav.modialogin.features.bffproxyfeature.directives.RespondDirectiveSpecification
-import no.nav.modialogin.features.bffproxyfeature.directives.SetHeaderDirectiveSpecification
 import java.lang.StringBuilder
 
 typealias ResponseDirectiveHandler = suspend PipelineContext<Unit, ApplicationCall>.() -> Unit
 typealias RequestDirectiveHandler = HttpRequestBuilder.(ApplicationCall) -> Unit
-class BFFProxy(initializingDirectives: List<String>) {
+class BFFProxy(private val handlers: List<DirectiveSpecification>) {
+    constructor(vararg handlers: DirectiveSpecification): this(handlers.toList())
+
     enum class DirectiveSpecificationType {
         RESPONSE, REQUEST
     }
     sealed interface DirectiveSpecification {
-        fun initialize() {}
         fun canHandle(directive: String): Boolean
         fun describe(directive: String, sb: StringBuilder)
         val type: DirectiveSpecificationType
@@ -37,21 +34,6 @@ class BFFProxy(initializingDirectives: List<String>) {
         val responseHandler: ResponseDirectiveHandler?,
         val requestHandler: RequestDirectiveHandler?
     )
-
-    private val handlers: List<DirectiveSpecification> = listOf(
-        SetHeaderDirectiveSpecification,
-        RespondDirectiveSpecification,
-        AADOnBehalfOfDirectiveSpecification
-    )
-
-    init {
-        log.info("Directives: $initializingDirectives")
-        initializingDirectives
-            .map(::findHandler)
-            .map { it.first }
-            .distinct()
-            .forEach { it.initialize() }
-    }
 
     fun parseDirectives(directives: List<String>): DirectiveHandlers {
         val parsedDirectives = directives

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/directives/RespondDirectiveSpecification.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/directives/RespondDirectiveSpecification.kt
@@ -8,7 +8,7 @@ import no.nav.modialogin.features.bffproxyfeature.BFFProxy
 import no.nav.modialogin.features.bffproxyfeature.ResponseDirectiveHandler
 import no.nav.personoversikt.common.utils.StringUtils.cutoff
 
-object RespondDirectiveSpecification : BFFProxy.ResponseDirectiveSpecification {
+class RespondDirectiveSpecification : BFFProxy.ResponseDirectiveSpecification {
     private val regexp = Regex("RESPOND (.*?) '(.*?)'")
     private data class Lexed(val code: HttpStatusCode, val body: String)
     override fun canHandle(directive: String): Boolean {

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/directives/SetHeaderDirectiveSpecification.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/features/bffproxyfeature/directives/SetHeaderDirectiveSpecification.kt
@@ -5,7 +5,7 @@ import no.nav.modialogin.features.bffproxyfeature.BFFProxy
 import no.nav.modialogin.features.bffproxyfeature.RequestDirectiveHandler
 import no.nav.personoversikt.common.utils.StringUtils.cutoff
 
-object SetHeaderDirectiveSpecification : BFFProxy.RequestDirectiveSpecification {
+class SetHeaderDirectiveSpecification : BFFProxy.RequestDirectiveSpecification {
     /**
      * Usage: SET_HEADER <header name> '<header value>'
      * Ex:

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/utils/AuthJedisPool.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/utils/AuthJedisPool.kt
@@ -3,21 +3,12 @@ package no.nav.modialogin.utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.modialogin.Logging
-import no.nav.personoversikt.common.utils.EnvUtils.getRequiredConfig
+import no.nav.modialogin.RedisConfig
 import redis.clients.jedis.Jedis
 import redis.clients.jedis.JedisPool
 
-object RedisUtils {
-    val pool: AuthJedisPool by lazy {
-        AuthJedisPool(
-            getRequiredConfig("REDIS_HOST"),
-            getRequiredConfig("REDIS_PASSWORD")
-        )
-    }
-}
-
-class AuthJedisPool(host: String, private val password: String) {
-    private val pool = JedisPool(host, 6379)
+class AuthJedisPool(private val config: RedisConfig) {
+    private val pool = JedisPool(config.host, 6379)
     suspend fun <T> useResource(block: (Jedis) -> T): T? {
         return withContext(Dispatchers.IO) {
             if (pool.isClosed) {
@@ -26,7 +17,7 @@ class AuthJedisPool(host: String, private val password: String) {
             } else {
                 runCatching {
                     pool.resource.use {
-                        it.auth(password)
+                        it.auth(config.password)
                         block(it)
                     }
                 }


### PR DESCRIPTION
directive-spesifikasjonene måtte gjøres til klasse (fremfor statiske `object`) slik at redispool kunne sendes inn
