### PR TITLE
[KAIZEN-0] registrerer redis og postgres til selftestgenerator

### DIFF
--- a/frontend-app/src/main/kotlin/no/nav/modialogin/DataSourceConfiguration.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/DataSourceConfiguration.kt
@@ -54,11 +54,10 @@ class DataSourceConfiguration(val env: FrontendAppConfig) {
                 .migrate()
         }
 
-        suspend fun <T> DataSource.useConnection(block: (Connection) -> T): T? {
+        suspend fun <T> DataSource.useConnection(block: (Connection) -> T): Result<T?> {
             return withContext(Dispatchers.IO) {
                 runCatching { this@useConnection.connection.use(block) }
                     .onFailure { Logging.log.error("Database-error", it) }
-                    .getOrNull()
             }
         }
     }

--- a/frontend-app/src/main/kotlin/no/nav/modialogin/utils/KotlinUtils.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/utils/KotlinUtils.kt
@@ -22,6 +22,8 @@ object KotlinUtils {
         throw error ?: IllegalStateException("Retry failed without error")
     }
 
+    fun <T> Result<T?>.filterNotNull(): Result<T> = this.mapCatching { checkNotNull(it) }
+
     const val callIdProperty = "callId"
     fun callId(): String {
         return MDC.get(callIdProperty) ?: UUID.randomUUID().toString()

--- a/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
+++ b/frontend-app/src/test/kotlin/no/nav/modialogin/LocalFrontendApp.kt
@@ -15,12 +15,12 @@ fun main() {
     System.setProperty("CSP_DIRECTIVES", "default-src 'self'; script-src 'self';")
     System.setProperty("REFERRER_POLICY", "no-referrer")
     System.setProperty("PROXY_CONFIG_FILE", "./frontend-app/proxy-config/proxy-config.json")
-    System.setProperty("UNLEASH_API_URL", "http://localhost:8080/unleash")
 
+    System.setProperty("UNLEASH_API_URL", "http://localhost:8080/unleash")
     System.setProperty("CDN_BUCKET_URL", "http://localhost:8091/cdn/frontend/")
 
-//    setupRedis()
-    setupPostgresql()
+    setupRedis()
+//    setupPostgresql()
     setupAzureAdEnv()
 
     startApplication()


### PR DESCRIPTION
Status på redis/postgres vil derfor starte å påvirke om appen blir satt til isReady ved oppstart.

Begge er satt med `critical=false` siden appen skal greie å håndtere at lagring er offline en periode
