### PR TITLE
[PROD] [KAIZEN-0] fikse clean timing bug

### DIFF
--- a/frontend-app/src/main/kotlin/no/nav/modialogin/persistence/PersistenceFactory.kt
+++ b/frontend-app/src/main/kotlin/no/nav/modialogin/persistence/PersistenceFactory.kt
@@ -4,10 +4,15 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.KSerializer
 import no.nav.modialogin.DataSourceConfiguration
 import no.nav.modialogin.FrontendAppConfig
+import no.nav.modialogin.Logging.log
 import kotlin.concurrent.fixedRateTimer
+import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.minutes
 
 object PersistenceFactory {
+    private val cleanupInitialDelay = 5.minutes
+    private val cleanupPeriod = 1.minutes
+
     fun <KEY, VALUE> create(
         scope: String,
         config: FrontendAppConfig,
@@ -23,17 +28,20 @@ object PersistenceFactory {
             JdbcPersistence(scope, dbConfig.userDataSource, keySerializer, valueSerializer)
         }
 
+        log.info("Starting cleanup timer [delay:${cleanupInitialDelay.inWholeSeconds}s, period:${cleanupPeriod.inWholeSeconds}s]")
         fixedRateTimer(
             daemon = true,
-            initialDelay = 5.minutes.inWholeMicroseconds,
-            period = 1.minutes.inWholeMicroseconds,
+            initialDelay = cleanupInitialDelay.inWholeMilliseconds,
+            period = cleanupPeriod.inWholeMilliseconds,
         ) {
-            runBlocking {
-                persistence.clean()
+            val time = measureTimeMillis {
+                runBlocking {
+                    persistence.clean()
+                }
             }
+            log.info("Persistence cleanup ran in $time ms")
         }
 
         return persistence
     }
-
 }


### PR DESCRIPTION
- 0642322 [KAIZEN-0] fikse clean timing bug
  `fixedRateTimer` forventer millisekunder, men fikk mikrosekund. Dette fører til at opprydding i databasen bare skjer hver 16time fremfor hvert minutt